### PR TITLE
Update V0001__Create_pagila_schema.sql.sql

### DIFF
--- a/src/main/resources/db/migration/V0001__Create_pagila_schema.sql.sql
+++ b/src/main/resources/db/migration/V0001__Create_pagila_schema.sql.sql
@@ -8,6 +8,8 @@ SET check_function_bodies = false;
 SET client_min_messages = warning;
 SET escape_string_warning = off;
 
+CREATE ROLE postgres;
+
 --
 -- Name: SCHEMA public; Type: COMMENT; Schema: -; Owner: postgres
 --


### PR DESCRIPTION
fix for #1, Docker Postgres 9.4 failure

fixes error when executing mvn clean verify with Postres 9.4:
org.postgresql.util.PSQLException: ERROR: role "postgres" does not exist



